### PR TITLE
Fix pool resource for Chef 14

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/cloudbau/ceph-cookbook/issues'
 source_url 'https://github.com/cloudbau/ceph-cookbook'
 chef_version '>= 12.5' if respond_to?(:chef_version)
-version '3.2.1'
+version '3.3.0'
 
 supports 'ubuntu'
 

--- a/resources/pool.rb
+++ b/resources/pool.rb
@@ -19,7 +19,7 @@ property :force, [TrueClass, FalseClass], default: false
 property :exists
 
 action :create do
-  if current_value.exists
+  if pool_exists?(new_resource.name)
     Chef::Log.info "#{new_resource} already exists - nothing to do."
   else
     converge_by("Creating #{new_resource}") do
@@ -29,18 +29,13 @@ action :create do
 end
 
 action :delete do
-  if current_value.exists
+  if pool_exists?(new_resource.name)
     converge_by("Deleting #{new_resource}") do
-      delete_pool
+      delete_pool(new_resource)
     end
   else
-    Chef::Log.info "#{current_value} does not exist - nothing to do."
+    Chef::Log.info "#{new_resource.name} does not exist - nothing to do."
   end
-end
-
-load_current_value do
-  name name
-  exists pool_exists?(name)
 end
 
 def create_pool(new_resource)

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -10,7 +10,6 @@ property :keyname, String
 property :key, String
 
 action :create do
-  # current_value is set in load_current_value
   # new_resource values are set by ceph_user resource (e.g., in
   # recipes/_ceph_controller.rb)
   name = new_resource.name


### PR DESCRIPTION
The current_value method doesn't work anymore, replace it in the pool
resource similar to what has been done in the user resource.

Drop an old comment along the way.

Tested with chef-client 14.13.11.